### PR TITLE
Update ZON target selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,13 +61,13 @@ async function handleZeitConsent(browserPage) {
 
             function onMutation(mutation) {
                 console.log(mutation);
-                if (!mutation[0].target.classList.contains('box--loading')) {
+                if (!mutation[0].target.classList.contains('option--loading')) {
                     onConsentInitialized();
                 }
             }
 
-            const observationTarget = document.querySelector('.box.js-only');
-            if (observationTarget.classList.contains('box--loading')) {
+            const observationTarget = document.querySelector('.option.option--tcf.js');
+            if (observationTarget.classList.contains('option--loading')) {
                 console.log('still loading');
                 const mutationObserver = new MutationObserver(onMutation);
                 mutationObserver.observe(observationTarget, { attributes: true });


### PR DESCRIPTION
Hallo Martin, Frohes Neues!!

Ich werde die News-Benchmark nochmal wiederbeleben, und habe dafür die Consentgabe bei uns upgedatet.

Für SPON bin ich mir nicht sicher, ob ich den versteckten `[data-consent-el="acceptAllButton"]` einblenden soll vorm Klicken, oder stattdessen `#spmsg-accept` anklicken. Wenn ich das richtig deute, ist ersteres euer Fallback und letzteres der Consent-Dienstleister?

Was ist denn überhaupt ein sinnvolles Verhalten für die Benchmark? 🤔

- echten Consent von SP und echte Werbung
- Fallback-Consent und Eigenwerbung
- oder sollte man zum Messen mit einem Adblocker unterwegs sein, um die eigentlichen Seiten zu vergleichen, und nicht die Werbung des Tages?